### PR TITLE
MethodCallOccurrence for NSubstitute was not counting calls with arguments correctly.

### DIFF
--- a/Source/Machine.Fakes.Adapters.NSubstitute/NSubstituteMethodCallOccurrence.cs
+++ b/Source/Machine.Fakes.Adapters.NSubstitute/NSubstituteMethodCallOccurrence.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using Machine.Fakes.Sdk;
 using NSubstitute;
-using NSubstitute.Exceptions;
 
 namespace Machine.Fakes.Adapters.NSubstitute
 {
@@ -24,38 +23,20 @@ namespace Machine.Fakes.Adapters.NSubstitute
         }
 
         #region IMethodCallOccurrence Members
-
         public void Times(int numberOfTimesTheMethodShouldHaveBeenCalled)
         {
-            var calls = CountCalls();
-            if (calls != numberOfTimesTheMethodShouldHaveBeenCalled)
-                throw new ReceivedCallsException(string.Format(
-                        "Expected {0} calls to the method but received {1}",
-                        numberOfTimesTheMethodShouldHaveBeenCalled,
-                        calls));
+            _func.Compile().Invoke(_fake.Received(numberOfTimesTheMethodShouldHaveBeenCalled));
         }
 
         public void OnlyOnce()
         {
-            var calls = CountCalls();
-            if (calls != 1)
-                throw new ReceivedCallsException(
-                    string.Format("Expected only 1 call to the method but received {0}", calls));
+            Times(1);
         }
 
         public void Twice()
         {
             Times(2);
         }
-
         #endregion
-
-        private int CountCalls()
-        {
-            var method = ((MethodCallExpression)_func.Body).Method;
-            return _fake
-                .ReceivedCalls()
-                .Select(x => x.GetMethodInfo()).Count(x => x == method);
-        }
     }
 }

--- a/Source/Machine.Fakes.Adapters.Specs/MethodCallOccurrenceSpecs.generated.cs
+++ b/Source/Machine.Fakes.Adapters.Specs/MethodCallOccurrenceSpecs.generated.cs
@@ -109,6 +109,24 @@ namespace Machine.Fakes.Adapters.Specs.RhinoMocks
 
         It should_not_throw_an_exception = () => _exception.ShouldBeNull();
     }
+
+    [Subject(typeof(RhinoFakeEngine))]
+    public class Given_a_command_was_configured_on_a_fake_when_verifying_whether_it_was_executed_only_once_with_a_given_parameter_but_was_executed_twice_in_total : WithCurrentEngine<RhinoFakeEngine>
+    {
+        static Exception _exception;
+        static IServiceContainer _fake;
+
+        Establish context = () =>
+        {
+            _fake = FakeEngineGateway.Fake<IServiceContainer>();
+            _fake.RemoveService(typeof(Object));
+            _fake.RemoveService(typeof(String));
+        };
+
+        Because of = () => _exception = Catch.Exception(() => _fake.WasToldTo(f => f.RemoveService(typeof(String))).OnlyOnce());
+
+        It should_not_throw_an_exception = () => _exception.ShouldBeNull();
+    }
 }
 
 namespace Machine.Fakes.Adapters.Specs.NSubstitute
@@ -209,6 +227,24 @@ namespace Machine.Fakes.Adapters.Specs.NSubstitute
         };
 
         Because of = () => _exception = Catch.Exception(() => _fake.WasToldTo(f => f.GetService(null)));
+
+        It should_not_throw_an_exception = () => _exception.ShouldBeNull();
+    }
+
+    [Subject(typeof(NSubstituteEngine))]
+    public class Given_a_command_was_configured_on_a_fake_when_verifying_whether_it_was_executed_only_once_with_a_given_parameter_but_was_executed_twice_in_total : WithCurrentEngine<NSubstituteEngine>
+    {
+        static Exception _exception;
+        static IServiceContainer _fake;
+
+        Establish context = () =>
+        {
+            _fake = FakeEngineGateway.Fake<IServiceContainer>();
+            _fake.RemoveService(typeof(Object));
+            _fake.RemoveService(typeof(String));
+        };
+
+        Because of = () => _exception = Catch.Exception(() => _fake.WasToldTo(f => f.RemoveService(typeof(String))).OnlyOnce());
 
         It should_not_throw_an_exception = () => _exception.ShouldBeNull();
     }
@@ -315,6 +351,24 @@ namespace Machine.Fakes.Adapters.Specs.Moq
 
         It should_not_throw_an_exception = () => _exception.ShouldBeNull();
     }
+
+    [Subject(typeof(MoqFakeEngine))]
+    public class Given_a_command_was_configured_on_a_fake_when_verifying_whether_it_was_executed_only_once_with_a_given_parameter_but_was_executed_twice_in_total : WithCurrentEngine<MoqFakeEngine>
+    {
+        static Exception _exception;
+        static IServiceContainer _fake;
+
+        Establish context = () =>
+        {
+            _fake = FakeEngineGateway.Fake<IServiceContainer>();
+            _fake.RemoveService(typeof(Object));
+            _fake.RemoveService(typeof(String));
+        };
+
+        Because of = () => _exception = Catch.Exception(() => _fake.WasToldTo(f => f.RemoveService(typeof(String))).OnlyOnce());
+
+        It should_not_throw_an_exception = () => _exception.ShouldBeNull();
+    }
 }
 
 namespace Machine.Fakes.Adapters.Specs.FakeItEasy
@@ -415,6 +469,24 @@ namespace Machine.Fakes.Adapters.Specs.FakeItEasy
         };
 
         Because of = () => _exception = Catch.Exception(() => _fake.WasToldTo(f => f.GetService(null)));
+
+        It should_not_throw_an_exception = () => _exception.ShouldBeNull();
+    }
+
+    [Subject(typeof(FakeItEasyEngine))]
+    public class Given_a_command_was_configured_on_a_fake_when_verifying_whether_it_was_executed_only_once_with_a_given_parameter_but_was_executed_twice_in_total : WithCurrentEngine<FakeItEasyEngine>
+    {
+        static Exception _exception;
+        static IServiceContainer _fake;
+
+        Establish context = () =>
+        {
+            _fake = FakeEngineGateway.Fake<IServiceContainer>();
+            _fake.RemoveService(typeof(Object));
+            _fake.RemoveService(typeof(String));
+        };
+
+        Because of = () => _exception = Catch.Exception(() => _fake.WasToldTo(f => f.RemoveService(typeof(String))).OnlyOnce());
 
         It should_not_throw_an_exception = () => _exception.ShouldBeNull();
     }

--- a/Source/Machine.Fakes.Adapters.Specs/MethodCallOccurrenceSpecs.tt
+++ b/Source/Machine.Fakes.Adapters.Specs/MethodCallOccurrenceSpecs.tt
@@ -118,5 +118,23 @@ namespace Machine.Fakes.Adapters.Specs.<#= allNamespaces[i] #>
 
         It should_not_throw_an_exception = () => _exception.ShouldBeNull();
     }
+
+    [Subject(typeof(<#= allEngines[i] #>))]
+    public class Given_a_command_was_configured_on_a_fake_when_verifying_whether_it_was_executed_only_once_with_a_given_parameter_but_was_executed_twice_in_total : WithCurrentEngine<<#= allEngines[i] #>>
+    {
+        static Exception _exception;
+        static IServiceContainer _fake;
+
+        Establish context = () =>
+        {
+            _fake = FakeEngineGateway.Fake<IServiceContainer>();
+            _fake.RemoveService(typeof(Object));
+            _fake.RemoveService(typeof(String));
+        };
+
+        Because of = () => _exception = Catch.Exception(() => _fake.WasToldTo(f => f.RemoveService(typeof(String))).OnlyOnce());
+
+        It should_not_throw_an_exception = () => _exception.ShouldBeNull();
+    }
 }
 <# } #>


### PR DESCRIPTION
The number of calls is counted incorrectly when the call includes arguments. 

It only fails for NSubstitute. The other mocking libraries handle it correctly. 

I've fixed the problem and and added a new unit test to the T4 file for _MethodCallOccurrenceSpecs.tt_.

For instance:
```cs
    public interface ICalculator
    {
        void Add(int x);
    }

    [Subject(typeof(ICalculator))]
    public class When_a_method_is_called_on_a_fake : WithFakes
    {
        Because of = () => 
        {
            The<ICalculator>().Add(1);
            The<ICalculator>().Add(2);
            The<ICalculator>().Add(3);
        };

        It should_be_able_to_verify_that = () => 
            The<ICalculator>()
                .WasToldTo(s => s.Add(2))
                .OnlyOnce();
    }
```

fails with

> Expected only 1 call to the method but received 3
   at Machine.Fakes.Adapters.NSubstitute.NSubstituteMethodCallOccurrence`1.OnlyOnce()

.
