### PR TITLE
Build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ _ReSharper.*
 *.swp
 NDependOut
 Source/GlobalAssemblyInfo.cs
-/Build
+Build
 /Release
 /Documentation
 

--- a/README.markdown
+++ b/README.markdown
@@ -21,7 +21,7 @@ Many credits for the ideas incorporated in this framework go to Jean Paul Boodho
 
 ## Building Machine.Fakes from source ##
 
-Just download the repository from github and run the build.cmd (or build.NoGit.cmd if you don't have git installed). The build of Machine.Fakes only requires the .NET Framework 4.0 to be installed on your machine. Everything else should work out-of-the-box. If not, please take the time to add an issue to this project. After a successful build you will find all the assemblies in a zip file under the "Release" folder.
+Just download the repository from github and run `build.ps1`. The build of Machine.Fakes requires .NET Core SDK 2.0.0 to be installed on your machine. Everything else should work out-of-the-box. If not, please take the time to add an issue to this project. After a successful build you will find the nupkgs in the "Build" folder under their respective project (e.g. `Source\Machine.Fakes\Build`).
 
 ## Getting Machine.Fakes via the NuGet package manager
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ assembly_info:
 
 build_script:
 - cmd: >-
-    powershell -f build.ps1 -CodeDirectory "Source" -TestsDirectory "Source" -PackageOutputDirectory "Build" -Package "Machine.Fakes","Machine.Fakes.FakeItEasy","Machine.Fakes.Moq","Machine.Fakes.NSubstitute","Machine.Fakes.Rhinomocks" -Version "%NUGET_VERSION%" -Configuration "%CONFIGURATION%"
+    powershell -f build.ps1 -Version "%NUGET_VERSION%" -Configuration "%CONFIGURATION%"
 artifacts:
 - path: Source\**\Build\*.nupkg
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,10 +1,10 @@
 Param(
     [string] $Configuration = "Debug",
-    [string] $CodeDirectory = ".",
-    [string] $TestsDirectory = ".",
+    [string] $CodeDirectory = "Source",
+    [string] $TestsDirectory = "Source",
     [string] $PackageOutputDirectory = "Build",
     [string] $Version,
-    [string[]] $Package
+    [string[]] $Package = @("Machine.Fakes","Machine.Fakes.FakeItEasy","Machine.Fakes.Moq","Machine.Fakes.NSubstitute","Machine.Fakes.Rhinomocks")
 )
 
 $tests = Get-ChildItem $TestsDirectory -Recurse -File -Filter "*.Specs.csproj"
@@ -26,7 +26,7 @@ if ($Version) {
     $projects | ForEach {
         Write-Host "Updating version: $($_.FullName)"
 
-        $foundVersion = $false; # replace only the first occurance of versin (assumes package version is on top)
+        $foundVersion = $false; # replace only the first occurance of version (assumes package version is on top)
 
         (Get-Content $_.FullName -ErrorAction Stop) |
             Foreach-Object {
@@ -74,10 +74,9 @@ if ($testsFailed) {
 
 # NuGet packaging
 
-Write-Host "Creating a nuget package in ${PackageOutputDirectory}"
-
-$Package | ForEach {
-    $_ -split "," | ForEach{
+if ($Package) {
+    $Package | ForEach {
+        Write-Host "Creating nuget package in $CodeDirectory\$_\$PackageOutputDirectory"
         Invoke-ExpressionExitCodeCheck "dotnet pack ${CodeDirectory}\$($_) -c ${Configuration} -o ${PackageOutputDirectory} /p:PackageVersion=${Version}"
     }
 }


### PR DESCRIPTION
I found a few problems when attempting to build. @robertcoltheart resolved a few, but still we have:

1. the readme gives bad instructions
2. if you run .\build.ps1, it tries to pack, but gives an error
3. if you provide a proper Package value on the command line, the packages go in the wrong place

I may be overstepping, but I took the liberty of updating the docs and "fixing" the build script. Some changes are a little opinionated…