### PR TITLE
Update support for .NET Core use

### DIFF
--- a/src/Machine.Fakes.Adapters.Specs/Bugs/Issue28.cs
+++ b/src/Machine.Fakes.Adapters.Specs/Bugs/Issue28.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD
+#if !NETSTANDARD && !NETCOREAPP && !NET46
 
 using System;
 using Machine.Fakes.Adapters.Rhinomocks;

--- a/src/Machine.Fakes.Adapters.Specs/Bugs/Run_more_than_one_behavior_config.cs
+++ b/src/Machine.Fakes.Adapters.Specs/Bugs/Run_more_than_one_behavior_config.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD
+#if !NETSTANDARD && !NETCOREAPP && !NET46
 
 using Machine.Fakes.Adapters.Rhinomocks;
 using Machine.Specifications;

--- a/src/Machine.Fakes.Adapters.Specs/CommandOptionsSpecs.generated.cs
+++ b/src/Machine.Fakes.Adapters.Specs/CommandOptionsSpecs.generated.cs
@@ -1,19 +1,10 @@
-﻿
-
-
-
-
-
-
-using System;
+﻿using System;
 using Machine.Fakes.Adapters.Specs.SampleCode;
 using Machine.Fakes.Internal;
 using Machine.Specifications;
 
-
-
-#if !NETSTANDARD
-
+#if !NETSTANDARD && !NETCOREAPP
+#if !NET46
 
 namespace Machine.Fakes.Adapters.Specs.Rhinomocks
 {
@@ -52,12 +43,8 @@ namespace Machine.Fakes.Adapters.Specs.Rhinomocks
 }
 
 #endif
+#endif
 
-
-
-
-
-#if !NETSTANDARD
 
 
 namespace Machine.Fakes.Adapters.Specs.NSubstitute
@@ -95,11 +82,6 @@ namespace Machine.Fakes.Adapters.Specs.NSubstitute
         It should_execute_the_configured_behavior = () => Catch.Exception(() => _fake.RemoveService(typeof(string))).ShouldNotBeNull();
     }
 }
-
-#endif
-
-
-
 
 
 
@@ -143,11 +125,6 @@ namespace Machine.Fakes.Adapters.Specs.Moq
 
 
 
-
-
-#if !NETSTANDARD
-
-
 namespace Machine.Fakes.Adapters.Specs.FakeItEasy
 {
 
@@ -183,7 +160,5 @@ namespace Machine.Fakes.Adapters.Specs.FakeItEasy
         It should_execute_the_configured_behavior = () => Catch.Exception(() => _fake.RemoveService(typeof(string))).ShouldNotBeNull();
     }
 }
-
-#endif
 
 

--- a/src/Machine.Fakes.Adapters.Specs/CommandOptionsSpecs.tt
+++ b/src/Machine.Fakes.Adapters.Specs/CommandOptionsSpecs.tt
@@ -6,16 +6,19 @@
 <#@ output extension="generated.cs" #>
 <# var allEngines = new[] { "RhinoFakeEngine", "NSubstituteEngine", "MoqFakeEngine", "FakeItEasyEngine" };  #>
 <# var allNamespaces = new[] { "Rhinomocks", "NSubstitute", "Moq", "FakeItEasy" };  #>
-<# var supportsNetStandard = new[] { false, false, true, false };  #>
+<# var supportsNetStandard = new[] { false, true, true, true };  #>
+<# var supportsNet46 = new[] { false, true, true, true }; #>
 using System;
 using Machine.Fakes.Adapters.Specs.SampleCode;
 using Machine.Fakes.Internal;
 using Machine.Specifications;
 <# for (int i = 0; i < allEngines.Length; i++) { #>
 
-
 <# if (!supportsNetStandard[i]) { #>
-#if !NETSTANDARD
+#if !NETSTANDARD && !NETCOREAPP
+<# } #>
+<# if (!supportsNet46[i]) { #>
+#if !NET46
 <# } #>
 
 namespace Machine.Fakes.Adapters.Specs.<#= allNamespaces[i] #>
@@ -55,6 +58,9 @@ namespace Machine.Fakes.Adapters.Specs.<#= allNamespaces[i] #>
 }
 
 <# if (!supportsNetStandard[i]) { #>
+#endif
+<# } #>
+<# if (!supportsNet46[i]) { #>
 #endif
 <# } #>
 

--- a/src/Machine.Fakes.Adapters.Specs/EngineSpecs.generated.cs
+++ b/src/Machine.Fakes.Adapters.Specs/EngineSpecs.generated.cs
@@ -3,7 +3,8 @@ using Machine.Fakes.Adapters.Specs.SampleCode;
 using Machine.Fakes.Internal;
 using Machine.Specifications;
 
-#if !NETSTANDARD
+#if !NETSTANDARD && !NETCOREAPP
+#if !NET46
 
 namespace Machine.Fakes.Adapters.Specs.Rhinomocks
 {
@@ -118,9 +119,9 @@ namespace Machine.Fakes.Adapters.Specs.Rhinomocks
 }
 
 #endif
+#endif
 
 
-#if !NETSTANDARD
 
 namespace Machine.Fakes.Adapters.Specs.NSubstitute
 {
@@ -234,7 +235,6 @@ namespace Machine.Fakes.Adapters.Specs.NSubstitute
     }
 }
 
-#endif
 
 
 
@@ -352,7 +352,6 @@ namespace Machine.Fakes.Adapters.Specs.Moq
 
 
 
-#if !NETSTANDARD
 
 namespace Machine.Fakes.Adapters.Specs.FakeItEasy
 {
@@ -466,6 +465,5 @@ namespace Machine.Fakes.Adapters.Specs.FakeItEasy
     }
 }
 
-#endif
 
 

--- a/src/Machine.Fakes.Adapters.Specs/EngineSpecs.tt
+++ b/src/Machine.Fakes.Adapters.Specs/EngineSpecs.tt
@@ -6,7 +6,8 @@
 <#@ output extension=".generated.cs" #>
 <# var allEngines = new[] { "RhinoFakeEngine", "NSubstituteEngine", "MoqFakeEngine", "FakeItEasyEngine" };  #>
 <# var allNamespaces = new[] { "Rhinomocks", "NSubstitute", "Moq", "FakeItEasy" };  #>
-<# var supportsNetStandard = new[] { false, false, true, false };  #>
+<# var supportsNetStandard = new[] { false, true, true, true };  #>
+<# var supportsNet46 = new[] { false, true, true, true }; #>
 using System;
 using Machine.Fakes.Adapters.Specs.SampleCode;
 using Machine.Fakes.Internal;
@@ -14,7 +15,10 @@ using Machine.Specifications;
 <# for (int i = 0; i < allEngines.Length; i++) { #>
 
 <# if (!supportsNetStandard[i]) { #>
-#if !NETSTANDARD
+#if !NETSTANDARD && !NETCOREAPP
+<# } #>
+<# if (!supportsNet46[i]) { #>
+#if !NET46
 <# } #>
 
 namespace Machine.Fakes.Adapters.Specs.<#= allNamespaces[i] #>
@@ -130,6 +134,9 @@ namespace Machine.Fakes.Adapters.Specs.<#= allNamespaces[i] #>
 }
 
 <# if (!supportsNetStandard[i]) { #>
+#endif
+<# } #>
+<# if (!supportsNet46[i]) { #>
 #endif
 <# } #>
 

--- a/src/Machine.Fakes.Adapters.Specs/InlineConstraintSpecs.generated.cs
+++ b/src/Machine.Fakes.Adapters.Specs/InlineConstraintSpecs.generated.cs
@@ -1,17 +1,9 @@
-﻿
-
-
-
-
-
-
-using Machine.Fakes.Adapters.Specs.SampleCode;
+﻿using Machine.Fakes.Adapters.Specs.SampleCode;
 using Machine.Fakes.Internal;
 using Machine.Specifications;
 
-
-#if !NETSTANDARD
-
+#if !NETSTANDARD && !NETCOREAPP
+#if !NET46
 
 namespace Machine.Fakes.Adapters.Specs.Rhinomocks
 {
@@ -432,9 +424,7 @@ namespace Machine.Fakes.Adapters.Specs.Rhinomocks
 }
 
 #endif
-
-
-
+#endif
 
 
 
@@ -855,9 +845,6 @@ namespace Machine.Fakes.Adapters.Specs.NSubstitute
         It should_trigger_the_configured_behavior = () => _configuredBehaviorWasTriggered.ShouldBeTrue();
     }
 }
-
-
-
 
 
 
@@ -1283,9 +1270,6 @@ namespace Machine.Fakes.Adapters.Specs.Moq
 
 
 
-
-
-
 namespace Machine.Fakes.Adapters.Specs.FakeItEasy
 {
 
@@ -1703,6 +1687,5 @@ namespace Machine.Fakes.Adapters.Specs.FakeItEasy
         It should_trigger_the_configured_behavior = () => _configuredBehaviorWasTriggered.ShouldBeTrue();
     }
 }
-
 
 

--- a/src/Machine.Fakes.Adapters.Specs/InlineConstraintSpecs.tt
+++ b/src/Machine.Fakes.Adapters.Specs/InlineConstraintSpecs.tt
@@ -7,13 +7,17 @@
 <# var allEngines = new[] { "RhinoFakeEngine", "NSubstituteEngine", "MoqFakeEngine", "FakeItEasyEngine" };  #>
 <# var allNamespaces = new[] { "Rhinomocks", "NSubstitute", "Moq", "FakeItEasy" };  #>
 <# var supportsNetStandard = new[] { false, true, true, true };  #>
+<# var supportsNet46 = new[] { false, true, true, true }; #>
 using Machine.Fakes.Adapters.Specs.SampleCode;
 using Machine.Fakes.Internal;
 using Machine.Specifications;
 <# for (int i = 0; i < allEngines.Length; i++) { #>
 
 <# if (!supportsNetStandard[i]) { #>
-#if !NETSTANDARD
+#if !NETSTANDARD && !NETCOREAPP
+<# } #>
+<# if (!supportsNet46[i]) { #>
+#if !NET46
 <# } #>
 
 namespace Machine.Fakes.Adapters.Specs.<#= allNamespaces[i] #>
@@ -435,6 +439,9 @@ namespace Machine.Fakes.Adapters.Specs.<#= allNamespaces[i] #>
 }
 
 <# if (!supportsNetStandard[i]) { #>
+#endif
+<# } #>
+<# if (!supportsNet46[i]) { #>
 #endif
 <# } #>
 

--- a/src/Machine.Fakes.Adapters.Specs/Machine.Fakes.Adapters.Specs.csproj
+++ b/src/Machine.Fakes.Adapters.Specs/Machine.Fakes.Adapters.Specs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>0.1.0</Version>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.0;netcoreapp2.2</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Machine.Fakes.Adapters.Specs/MethodCallOccurrenceSpecs.generated.cs
+++ b/src/Machine.Fakes.Adapters.Specs/MethodCallOccurrenceSpecs.generated.cs
@@ -1,18 +1,10 @@
-﻿
-
-
-
-
-
-
-using System;
+﻿using System;
 using Machine.Fakes.Adapters.Specs.SampleCode;
 using Machine.Fakes.Internal;
 using Machine.Specifications;
 
-
-#if !NETSTANDARD
-
+#if !NETSTANDARD && !NETCOREAPP
+#if !NET46
 
 
 namespace Machine.Fakes.Adapters.Specs.Rhinomocks
@@ -140,10 +132,8 @@ namespace Machine.Fakes.Adapters.Specs.Rhinomocks
 }
 
 #endif
+#endif
 
-
-
-#if !NETSTANDARD
 
 
 
@@ -270,9 +260,6 @@ namespace Machine.Fakes.Adapters.Specs.NSubstitute
         It should_not_throw_an_exception = () => _exception.ShouldBeNull();
     }
 }
-
-#endif
-
 
 
 
@@ -405,9 +392,6 @@ namespace Machine.Fakes.Adapters.Specs.Moq
 
 
 
-#if !NETSTANDARD
-
-
 
 namespace Machine.Fakes.Adapters.Specs.FakeItEasy
 {
@@ -533,5 +517,4 @@ namespace Machine.Fakes.Adapters.Specs.FakeItEasy
     }
 }
 
-#endif
 

--- a/src/Machine.Fakes.Adapters.Specs/MethodCallOccurrenceSpecs.tt
+++ b/src/Machine.Fakes.Adapters.Specs/MethodCallOccurrenceSpecs.tt
@@ -6,7 +6,8 @@
 <#@ output extension=".generated.cs" #>
 <# var allEngines = new[] { "RhinoFakeEngine", "NSubstituteEngine", "MoqFakeEngine", "FakeItEasyEngine" };  #>
 <# var allNamespaces = new[] { "Rhinomocks", "NSubstitute", "Moq", "FakeItEasy" };  #>
-<# var supportsNetStandard = new[] { false, false, true, false };  #>
+<# var supportsNetStandard = new[] { false, true, true, true };  #>
+<# var supportsNet46 = new[] { false, true, true, true }; #>
 using System;
 using Machine.Fakes.Adapters.Specs.SampleCode;
 using Machine.Fakes.Internal;
@@ -14,7 +15,10 @@ using Machine.Specifications;
 <# for (int i = 0; i < allEngines.Length; i++) { #>
 
 <# if (!supportsNetStandard[i]) { #>
-#if !NETSTANDARD
+#if !NETSTANDARD && !NETCOREAPP
+<# } #>
+<# if (!supportsNet46[i]) { #>
+#if !NET46
 <# } #>
 
 
@@ -145,4 +149,8 @@ namespace Machine.Fakes.Adapters.Specs.<#= allNamespaces[i] #>
 <# if (!supportsNetStandard[i]) { #>
 #endif
 <# } #>
+<# if (!supportsNet46[i]) { #>
+#endif
+<# } #>
+
 <# } #>

--- a/src/Machine.Fakes.Adapters.Specs/PropertyBehaviorSpecs.generated.cs
+++ b/src/Machine.Fakes.Adapters.Specs/PropertyBehaviorSpecs.generated.cs
@@ -1,18 +1,10 @@
-﻿
-
-
-
-
-
-
-using Machine.Fakes.Adapters.Specs.SampleCode;
+﻿using Machine.Fakes.Adapters.Specs.SampleCode;
 using Machine.Fakes.Internal;
 using Machine.Specifications;
 
 
-
-#if !NETSTANDARD
-
+#if !NETSTANDARD && !NETCOREAPP
+#if !NET46
 
 namespace Machine.Fakes.Adapters.Specs.Rhinomocks
 {
@@ -77,11 +69,8 @@ namespace Machine.Fakes.Adapters.Specs.Rhinomocks
 }
 
 #endif
+#endif
 
-
-
-
-#if !NETSTANDARD
 
 
 namespace Machine.Fakes.Adapters.Specs.NSubstitute
@@ -145,10 +134,6 @@ namespace Machine.Fakes.Adapters.Specs.NSubstitute
         static IProperties _fake;
     }
 }
-
-#endif
-
-
 
 
 
@@ -218,10 +203,6 @@ namespace Machine.Fakes.Adapters.Specs.Moq
 
 
 
-
-#if !NETSTANDARD
-
-
 namespace Machine.Fakes.Adapters.Specs.FakeItEasy
 {
 
@@ -283,7 +264,5 @@ namespace Machine.Fakes.Adapters.Specs.FakeItEasy
         static IProperties _fake;
     }
 }
-
-#endif
 
 

--- a/src/Machine.Fakes.Adapters.Specs/PropertyBehaviorSpecs.tt
+++ b/src/Machine.Fakes.Adapters.Specs/PropertyBehaviorSpecs.tt
@@ -6,7 +6,8 @@
 <#@ output extension=".generated.cs" #>
 <# var allEngines = new[] { "RhinoFakeEngine", "NSubstituteEngine", "MoqFakeEngine", "FakeItEasyEngine" };  #>
 <# var allNamespaces = new[] { "Rhinomocks", "NSubstitute", "Moq", "FakeItEasy" };  #>
-<# var supportsNetStandard = new[] { false, false, true, false };  #>
+<# var supportsNetStandard = new[] { false, true, true, true };  #>
+<# var supportsNet46 = new[] { false, true, true, true }; #>
 using Machine.Fakes.Adapters.Specs.SampleCode;
 using Machine.Fakes.Internal;
 using Machine.Specifications;
@@ -14,7 +15,10 @@ using Machine.Specifications;
 <# for (int i = 0; i < allEngines.Length; i++) { #>
 
 <# if (!supportsNetStandard[i]) { #>
-#if !NETSTANDARD
+#if !NETSTANDARD && !NETCOREAPP
+<# } #>
+<# if (!supportsNet46[i]) { #>
+#if !NET46
 <# } #>
 
 namespace Machine.Fakes.Adapters.Specs.<#= allNamespaces[i] #>
@@ -80,6 +84,9 @@ namespace Machine.Fakes.Adapters.Specs.<#= allNamespaces[i] #>
 }
 
 <# if (!supportsNetStandard[i]) { #>
+#endif
+<# } #>
+<# if (!supportsNet46[i]) { #>
 #endif
 <# } #>
 

--- a/src/Machine.Fakes.Adapters.Specs/QueryOptionsSpecs.generated.cs
+++ b/src/Machine.Fakes.Adapters.Specs/QueryOptionsSpecs.generated.cs
@@ -1,19 +1,11 @@
-﻿
-
-
-
-
-
-
-using System;
+﻿using System;
 using System.Linq;
 using Machine.Fakes.Adapters.Specs.SampleCode;
 using Machine.Fakes.Internal;
 using Machine.Specifications;
 
-
-#if !NETSTANDARD
-
+#if !NETSTANDARD && !NETCOREAPP
+#if !NET46
 
 
 namespace Machine.Fakes.Adapters.Specs.Rhinomocks
@@ -97,11 +89,8 @@ namespace Machine.Fakes.Adapters.Specs.Rhinomocks
 }
 
 #endif
+#endif
 
-
-
-
-#if !NETSTANDARD
 
 
 
@@ -184,10 +173,6 @@ namespace Machine.Fakes.Adapters.Specs.NSubstitute
         It should_execute_the_configured_behavior = () => Catch.Exception(() => _fake.GetService(typeof(string))).ShouldNotBeNull();
     }
 }
-
-#endif
-
-
 
 
 
@@ -277,10 +262,6 @@ namespace Machine.Fakes.Adapters.Specs.Moq
 
 
 
-#if !NETSTANDARD
-
-
-
 namespace Machine.Fakes.Adapters.Specs.FakeItEasy
 {
 	using Machine.Fakes.Adapters.FakeItEasy;
@@ -360,7 +341,5 @@ namespace Machine.Fakes.Adapters.Specs.FakeItEasy
         It should_execute_the_configured_behavior = () => Catch.Exception(() => _fake.GetService(typeof(string))).ShouldNotBeNull();
     }
 }
-
-#endif
 
 

--- a/src/Machine.Fakes.Adapters.Specs/QueryOptionsSpecs.tt
+++ b/src/Machine.Fakes.Adapters.Specs/QueryOptionsSpecs.tt
@@ -6,7 +6,8 @@
 <#@ output extension="generated.cs" #>
 <# var allEngines = new[] { "RhinoFakeEngine", "NSubstituteEngine", "MoqFakeEngine", "FakeItEasyEngine" };  #>
 <# var allNamespaces = new[] { "Rhinomocks", "NSubstitute", "Moq", "FakeItEasy" };  #>
-<# var supportsNetStandard = new[] { false, false, true, false };  #>
+<# var supportsNetStandard = new[] { false, true, true, true };  #>
+<# var supportsNet46 = new[] { false, true, true, true }; #>
 using System;
 using System.Linq;
 using Machine.Fakes.Adapters.Specs.SampleCode;
@@ -15,7 +16,10 @@ using Machine.Specifications;
 <# for (int i = 0; i < allEngines.Length; i++) { #>
 
 <# if (!supportsNetStandard[i]) { #>
-#if !NETSTANDARD
+#if !NETSTANDARD && !NETCOREAPP
+<# } #>
+<# if (!supportsNet46[i]) { #>
+#if !NET46
 <# } #>
 
 
@@ -100,6 +104,9 @@ namespace Machine.Fakes.Adapters.Specs.<#= allNamespaces[i] #>
 }
 
 <# if (!supportsNetStandard[i]) { #>
+#endif
+<# } #>
+<# if (!supportsNet46[i]) { #>
 #endif
 <# } #>
 

--- a/src/Machine.Fakes.Adapters.Specs/RhinoMocks/CommandOptionsSpecs.cs
+++ b/src/Machine.Fakes.Adapters.Specs/RhinoMocks/CommandOptionsSpecs.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD
+#if !NETSTANDARD && !NETCOREAPP && !NET46
 using System;
 using Machine.Fakes.Adapters.Rhinomocks;
 using Machine.Fakes.Adapters.Specs.SampleCode;

--- a/src/Machine.Fakes.Examples/Machine.Fakes.Examples.csproj
+++ b/src/Machine.Fakes.Examples/Machine.Fakes.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>0.1.0</Version>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.0;netcoreapp2.2</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Machine.Fakes.FakeItEasy/Machine.Fakes.FakeItEasy.csproj
+++ b/src/Machine.Fakes.FakeItEasy/Machine.Fakes.FakeItEasy.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>0.1.0</Version>
-    <TargetFrameworks>net40;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard1.6;netstandard2.0</TargetFrameworks>
     <Description>Machine.Fakes attempts to simplify the usage of such frameworks on top of Machine.Specifications by helping to reduce a lot of the typical fake framwork related clutter code in specifications. If you choose so, Machine.Fakes even helps you to stay mostly independent of a concrete fake framework by providing a little wrapper API and a provider model for fake frameworks. </Description>
     <Authors>Machine Specifications</Authors>
     <PackageTags>tdd;bdd;testing;unittest;fakes;mocks;mspec;mfakes</PackageTags>

--- a/src/Machine.Fakes.Moq/Machine.Fakes.Moq.csproj
+++ b/src/Machine.Fakes.Moq/Machine.Fakes.Moq.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>0.1.0</Version>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <Description>Machine.Fakes attempts to simplify the usage of such frameworks on top of Machine.Specifications by helping to reduce a lot of the typical fake framwork related clutter code in specifications. If you choose so, Machine.Fakes even helps you to stay mostly independent of a concrete fake framework by providing a little wrapper API and a provider model for fake frameworks. </Description>
     <Authors>Machine Specifications</Authors>
     <PackageTags>tdd;bdd;testing;unittest;fakes;mocks;mspec;mfakes</PackageTags>

--- a/src/Machine.Fakes.NSubstitute/Machine.Fakes.NSubstitute.csproj
+++ b/src/Machine.Fakes.NSubstitute/Machine.Fakes.NSubstitute.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>0.1.0</Version>
-    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.3;netstandard2.0</TargetFrameworks>
     <Description>Machine.Fakes attempts to simplify the usage of such frameworks on top of Machine.Specifications by helping to reduce a lot of the typical fake framwork related clutter code in specifications. If you choose so, Machine.Fakes even helps you to stay mostly independent of a concrete fake framework by providing a little wrapper API and a provider model for fake frameworks. </Description>
     <Authors>Machine Specifications</Authors>
     <PackageTags>tdd;bdd;testing;unittest;fakes;mocks;mspec;mfakes</PackageTags>

--- a/src/Machine.Fakes.Specs/Machine.Fakes.Specs.csproj
+++ b/src/Machine.Fakes.Specs/Machine.Fakes.Specs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>0.1.0</Version>
-    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp2.0;netcoreapp2.2</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Machine.Fakes/Machine.Fakes.csproj
+++ b/src/Machine.Fakes/Machine.Fakes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <TargetFrameworks>net40;net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <Description>Machine.Fakes attempts to simplify the usage of such frameworks on top of Machine.Specifications by helping to reduce a lot of the typical fake framwork related clutter code in specifications. If you choose so, Machine.Fakes even helps you to stay mostly independent of a concrete fake framework by providing a little wrapper API and a provider model for fake frameworks. </Description>
     <Authors>Machine Specifications</Authors>
     <PackageTags>tdd;bdd;testing;unittest;fakes;mocks;mspec;mfakes</PackageTags>


### PR DESCRIPTION
FakeItEasy and NSubstitute now support .NET Core, enabled testing for those adapters.

netstandard2.0 and netcoreapp2.2 are now available and needed to test MVC apps with Moq. Added framework targets for these.